### PR TITLE
fix tabs aligning

### DIFF
--- a/packages/app/client/src/ui/pages/Learn/sections/SectionTabs.js
+++ b/packages/app/client/src/ui/pages/Learn/sections/SectionTabs.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Grid from '@material-ui/core/Grid'
 import { Tabs } from '../../../molecules'
 import { SectionContainer } from '../../../templates'
 import { makeStyles } from '@material-ui/core/styles'
@@ -39,8 +40,10 @@ const SectionTabs = () => {
 
   return (
     <div className={classes.container}>
-      <SectionContainer padding={0} mobilePadding={0} justify="center" lg={10}>
-        <Tabs handleChange={onTabChange} tabs={filteredTabs} className={classes.tabs} />
+      <SectionContainer padding={0} mobilePadding={0} justify="center">
+        <Grid item xs={12} md={11}>
+          <Tabs handleChange={onTabChange} tabs={filteredTabs} className={classes.tabs} />
+        </Grid>
       </SectionContainer>
     </div>
   )


### PR DESCRIPTION
This pull request fixes the Learn page tabs aligning.

<img width="926" alt="tabs_align" src="https://user-images.githubusercontent.com/12929857/116288530-834aaf00-a789-11eb-9ea1-fd115c782e3b.png">
